### PR TITLE
Use queues to process CAN frames in order

### DIFF
--- a/lwip/cannelloni.c
+++ b/lwip/cannelloni.c
@@ -54,6 +54,15 @@ static struct canfd_frame *queue_take(frames_queue_t *q)
   return frame;
 }
 
+static struct canfd_frame *queue_peek(frames_queue_t *q)
+{
+  if (q->head == q->tail) {
+    return NULL;
+  }
+
+  return &(q->frames[q->head]);
+}
+
 void init_cannelloni(cannelloni_handle_t* handle)
 {
   handle->sequence_number = 0;
@@ -189,9 +198,11 @@ void transmit_can_frames(cannelloni_handle_t *const handle)
 {
   if (!handle->Init.can_tx_fn)
     return;
-  struct canfd_frame *frame = queue_take(&handle->tx_queue);
+  struct canfd_frame *frame = queue_peek(&handle->tx_queue);
   if (frame) {
-    handle->Init.can_tx_fn(handle, frame);
+    if (handle->Init.can_tx_fn(handle, frame)) {
+      queue_take(&handle->tx_queue);
+    }
   }
 }
 

--- a/lwip/cannelloni.c
+++ b/lwip/cannelloni.c
@@ -84,7 +84,7 @@ void init_cannelloni(cannelloni_handle_t* handle)
 void handle_cannelloni_frame(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, uint16_t port)
 {
   cannelloni_handle_t *const handle = (cannelloni_handle_t *const)arg;
-  if (p != NULL) {
+  if (p != NULL && p->tot_len > CANNELLONI_DATA_PACKET_BASE_SIZE) {
     struct cannelloni_data_packet *data;
     uint8_t error = 0;
     /* Check for OP Code */
@@ -95,10 +95,6 @@ void handle_cannelloni_frame(void *arg, struct udp_pcb *pcb, struct pbuf *p, con
     }
     if (data->op_code != CNL_DATA) {
       /* Received wrong OP code */
-      error = 1;
-    }
-    if (ntohs(data->count) == 0) {
-      /* Received empty packet */
       error = 1;
     }
     if (!error) {
@@ -145,6 +141,9 @@ void handle_cannelloni_frame(void *arg, struct udp_pcb *pcb, struct pbuf *p, con
         }
       }
     }
+  }
+
+  if(p) {
     pbuf_free(p);
   }
 }

--- a/lwip/cannelloni.c
+++ b/lwip/cannelloni.c
@@ -210,10 +210,12 @@ void transmit_can_frames(cannelloni_handle_t *const handle)
   if (!handle->Init.can_tx_fn)
     return;
   struct canfd_frame *frame = queue_peek(&handle->tx_queue);
-  if (frame) {
-    if (handle->Init.can_tx_fn(handle, frame)) {
-      queue_take(&handle->tx_queue);
-    }
+  while (frame && handle->Init.can_tx_fn(handle, frame)) {
+    /* drop CAN frame as it was processed by CAN driver */
+    queue_take(&handle->tx_queue);
+
+    /* peek at next CAN frame */
+    frame = queue_peek(&handle->tx_queue);
   }
 }
 

--- a/lwip/cannelloni.c
+++ b/lwip/cannelloni.c
@@ -161,13 +161,13 @@ void transmit_udp_frame(cannelloni_handle_t* handle)
   }
 
   struct pbuf *p = pbuf_alloc(PBUF_TRANSPORT, 1200, PBUF_RAM);
-  uint16_t length = 0;
-  uint16_t frameCount = 0;
-  uint8_t *data = (uint8_t*) p->payload + CANNELLONI_DATA_PACKET_BASE_SIZE;
   if (!p) {
     /* allocation error */
     return;
   }
+  uint16_t length = 0;
+  uint16_t frameCount = 0;
+  uint8_t *data = (uint8_t*) p->payload + CANNELLONI_DATA_PACKET_BASE_SIZE;
 
   do {
     data[0] = frame->can_id >> 24 & 0x000000ff;

--- a/lwip/cannelloni.c
+++ b/lwip/cannelloni.c
@@ -108,31 +108,41 @@ void handle_cannelloni_frame(void *arg, struct udp_pcb *pcb, struct pbuf *p, con
           break;
         }
         /* We got at least a complete canfd_frame header */
+        canid_t can_id = (rawData[pos] << 24) | (rawData[pos+1] << 16) | (rawData[pos+2] << 8) | (rawData[pos+3]);;
+        pos += sizeof(canid_t);
+
+        uint8_t len = rawData[pos++];
+        uint8_t dlc = len & ~CANFD_FRAME;
+
+        /* If this is a CAN FD frame, also retrieve the flags */
+        uint8_t flags = 0;
+        if (len & CANFD_FRAME) {
+          flags = rawData[pos++];
+        }
+        /* RTR Frames have no data section although they have a dlc */
+        if ((can_id & CAN_RTR_FLAG) == 0) {
+          /* Check again now that we know the dlc */
+          if (pos + dlc > p->tot_len) {
+            /* Received incomplete packet / can header corrupt! */
+            error = 1;
+            break;
+          }
+        }
+
         struct canfd_frame *frame = queue_put(&handle->tx_queue);
         if (!frame) {
           /* Allocation error */
           error = 1;
           break;
         }
-        frame->can_id = (rawData[pos] << 24) | (rawData[pos+1] << 16) | (rawData[pos+2] << 8) | (rawData[pos+3]);;
-        pos += sizeof(canid_t);
+        frame->can_id = can_id;
+        frame->len = len;
+        frame->flags = flags;
 
-        frame->len = rawData[pos++];
-
-        /* If this is a CAN FD frame, also retrieve the flags */
-        if (frame->len & CANFD_FRAME) {
-          frame->flags = rawData[pos++];
-        }
-        /* RTR Frames have no data section although they have a dlc */
-        if ((frame->can_id & CAN_RTR_FLAG) == 0) {
-          /* Check again now that we know the dlc */
-          if (pos+canfd_len(frame) > p->tot_len) {
-            /* Received incomplete packet / can header corrupt! */
-            error = 1;
-            break;
-          }
-          memcpy(frame->data, rawData + pos, canfd_len(frame));
-          pos += canfd_len(frame);
+        /* RTR Frames have no data */
+        if ((can_id & CAN_RTR_FLAG) == 0) {
+          memcpy(frame->data, rawData + pos, dlc);
+          pos += dlc;
         }
       }
     }

--- a/lwip/cannelloni.c
+++ b/lwip/cannelloni.c
@@ -108,7 +108,7 @@ void handle_cannelloni_frame(void *arg, struct udp_pcb *pcb, struct pbuf *p, con
           break;
         }
         /* We got at least a complete canfd_frame header */
-        canid_t can_id = (rawData[pos] << 24) | (rawData[pos+1] << 16) | (rawData[pos+2] << 8) | (rawData[pos+3]);;
+        canid_t can_id = (rawData[pos] << 24) | (rawData[pos+1] << 16) | (rawData[pos+2] << 8) | (rawData[pos+3]);
         pos += sizeof(canid_t);
 
         uint8_t len = rawData[pos++];

--- a/lwip/cannelloni.h
+++ b/lwip/cannelloni.h
@@ -70,6 +70,13 @@ struct canfd_frame  {
 	uint8_t    data[CNL_CANFD_MAX_DLEN] __attribute__((aligned(8)));
 };
 
+typedef struct {
+  size_t head;
+  size_t tail;
+  size_t count;
+  struct canfd_frame *frames;
+} frames_queue_t;
+
 typedef struct cannelloni_handle cannelloni_handle_t;
 
 typedef void (*cnl_can_tx_fn)(cannelloni_handle_t *const, struct canfd_frame *const);
@@ -88,8 +95,9 @@ typedef struct cannelloni_handle {
     void *user_data;
   } Init;
 
-  volatile int32_t can_tx_frames_pos;
-  volatile int32_t can_rx_frames_pos;
+  frames_queue_t tx_queue;
+  frames_queue_t rx_queue;
+
   uint32_t sequence_number;
   struct udp_pcb *udp_pcb;
   uint32_t udp_rx_count;
@@ -104,7 +112,6 @@ void run_cannelloni(cannelloni_handle_t *const handle);
 
 void handle_cannelloni_frame(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, uint16_t port);
 
-struct canfd_frame* get_can_tx_frame(cannelloni_handle_t *const handle);
 struct canfd_frame* get_can_rx_frame(cannelloni_handle_t *const handle);
 
 #endif

--- a/lwip/cannelloni.h
+++ b/lwip/cannelloni.h
@@ -23,6 +23,7 @@
 #define _CANNELLONI_H
 
 #include "stdint.h"
+#include "stdbool.h"
 #include "ip_addr.h"
 #include "pbuf.h"
 
@@ -79,7 +80,7 @@ typedef struct {
 
 typedef struct cannelloni_handle cannelloni_handle_t;
 
-typedef void (*cnl_can_tx_fn)(cannelloni_handle_t *const, struct canfd_frame *const);
+typedef bool (*cnl_can_tx_fn)(cannelloni_handle_t *const, struct canfd_frame *const);
 typedef void (*cnl_can_rx_fn)(cannelloni_handle_t *const);
 
 typedef struct cannelloni_handle {


### PR DESCRIPTION
CAN frames are currently put into stack/LIFO so last CAN frame is processed as a first. This behavior causes sending older data after newer one for example.

With queues we can process first CAN frame as a first, but then in depends on CAN driver and message ID priority.
Few other things were fixed/improved:
- incomplete CAN frame received over UDP is dropped (wrong DLC without data can lead to memory issues from CAN driver for example)
- CAN driver tx function (`cnl_can_tx_fn`) can return `false` so frame transmission will be retried next time instead of dropping it
- `flags` is zero if there are no flags
